### PR TITLE
fix: remove uv.lock from .gitignore to track dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ todo/*
 *.parquet
 specific_tests
 
-uv.lock
 .python-version
 pytestdebug.log


### PR DESCRIPTION
## Summary
- Remove `uv.lock` from `.gitignore` to ensure consistent dependency versions across all environments

## Rationale
The `uv.lock` file should be committed to version control as it:
- Ensures reproducible builds across different environments
- Prevents dependency version mismatches between developers
- Follows best practices for modern Python package managers (similar to `package-lock.json` in npm or `Cargo.lock` in Rust)

## Changes
- Removed `uv.lock` entry from `.gitignore`

## Test Plan
- [x] Verified `.gitignore` is updated correctly
- [x] Confirmed no existing `uv.lock` file is affected
- [ ] Future `uv.lock` files will be properly tracked by Git